### PR TITLE
fix: Add RegisterFilterLib stub needed for newer MdePkg.

### DIFF
--- a/PayloadModPkg.dsc
+++ b/PayloadModPkg.dsc
@@ -40,7 +40,7 @@
   DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   ModuleEntryLib|BootloaderCommonPkg/Library/ModuleEntryLib/ModuleEntryLib.inf
-
+  RegisterFilterLib|MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
 
 [Components]
 !if $(MICRO_PYTHON)


### PR DESCRIPTION
MdePkg BaseLib requires RegisterFilterLib class, and a build error will occur if it's missing.